### PR TITLE
Printed summary on run end

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+name: Test
+on: workflow_dispatch
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: yarn install
+      - run: yarn test

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "@actions/core": "1.9.1",
     "mocha": "9.0.0"
+  },
+  "peerDependencies": {
+    "ms": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "test": "mocha --reporter index.js",
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn publish && git push --follow-tags; fi"
   },
   "dependencies": {

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,6 +1,12 @@
 const assert = require("assert");
 
 describe("when having a failing test", function() {
+  it("can succeed", () => {
+    assert(1 === 1, "Something is seriously wrong");
+  });
+  it.skip("can skip", () => {
+    throw new Error("Didn't expect this to run");
+  });
   it("generates a report", function() {
     assert(2 === 1, "Expected 2 to equal 1, :shrug:");
   });


### PR DESCRIPTION
This solves #15 by writing summary to the output.
I added a succeeding and pending test to verify the output and I also added a GitHub Actions workflow to test this:

<img width="1080" alt="Screenshot 2023-04-06 at 20 14 31" src="https://user-images.githubusercontent.com/1243959/230461902-adeaf4a9-af57-4604-b8cf-ada1da4cdc30.png">

Feel free to pick whatever you want from the branch.
